### PR TITLE
  Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Depends:
 Imports: 
     methods,
     Rcpp (>= 0.12.0),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     ggplot2 (>= 3.3.2), 
     nlme (>= 3.1.152), 
     stats,
@@ -59,6 +59,6 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make

--- a/inst/stan/global.stan
+++ b/inst/stan/global.stan
@@ -1,5 +1,5 @@
 data {
-#include /inst/stan/include/data.stan
+#include /include/data.stan
  }
 transformed data{
   int<lower=0> M_overall = M_is + M_oos; // number of observations (is+oos)
@@ -24,11 +24,11 @@ transformed data{
   }
 }
 parameters {
-#include /inst/stan/include/parameters.stan
+#include /include/parameters.stan
 }
 
 transformed parameters {
-#include /inst/stan/include/transf_par_declaration.stan
+#include /include/transf_par_declaration.stan
 
 // Regression coefficients - Fixed effect
   if(prior_coeff==0) { // normal prior
@@ -52,19 +52,19 @@ transformed parameters {
   }
 
 // Overall random effect part
-#include /inst/stan/include/transf_par_reff.stan
+#include /include/transf_par_reff.stan
 
   // diversi theta a seconda delle verosimiglianze
   if(likelihood==0){ // beta
-#include /inst/stan/include/transf_par_beta.stan
+#include /include/transf_par_beta.stan
   }else if(likelihood==1){ // FB
   // da capire OOS//
   /////////////////
-#include /inst/stan/include/transf_par_FB.stan
+#include /include/transf_par_FB.stan
   }else if(likelihood==2){ // ZIB
-#include /inst/stan/include/transf_par_ZIB.stan
+#include /include/transf_par_ZIB.stan
   }else if(likelihood==3){// beta FFT
-#include /inst/stan/include/transf_par_ZIBalt.stan
+#include /include/transf_par_ZIBalt.stan
   }
 }
 model{
@@ -186,8 +186,8 @@ model{
 generated quantities{
   vector[M_is] log_lik;
   vector[M_is] y_rep;
-  real psi_OOS[1];
-  real v_oos[1];
+  array[1] real psi_OOS;
+  array[1] real v_oos;
   int label_mixt;
   vector[inflation == 2 ? 3:0] probs;
   vector<lower=0,upper=1>[likelihood != 1 ? M_oos:0]  theta_oos;
@@ -201,7 +201,7 @@ generated quantities{
     }
   // add
     for(i in 1:M_oos) { // OOS units
-#include /inst/stan/include/gen_reff_OOS.stan
+#include /include/gen_reff_OOS.stan
       if(intercept == 0) {
         theta_oos[i] = inv_logit(X_oos[i,] * beta + reffs_oos[i] + v_oos[1]);
       }else{
@@ -209,11 +209,11 @@ generated quantities{
       }
     }
   }else if(likelihood == 1){ //FB
-#include /inst/stan/include/gen_FB.stan
+#include /include/gen_FB.stan
   }else if(likelihood == 2) { //ZIB
-#include /inst/stan/include/gen_ZIB.stan
+#include /include/gen_ZIB.stan
   }else if(likelihood==3) {//FFT beta
-#include /inst/stan/include/gen_ZIB_alt.stan
+#include /include/gen_ZIB_alt.stan
   }
 }
 

--- a/inst/stan/include/data.stan
+++ b/inst/stan/include/data.stan
@@ -25,24 +25,24 @@ vector<lower=0>[M_is] disp; // dispersion parameter
 vector<lower=0>[M_is] m_d; // area observations
 
 // Position indices
-int<lower=0> indices_is[M_is]; //indices units in sample
-int<lower=0> indices_oos[M_oos]; //indices units out of sample
-int<lower=0> indices_spat[D]; //indices ordering the spatial structure
-int<lower=0> indices_temp[M_is+M_oos,2]; //indexing time matrix with original obs vector
+array[M_is] int<lower=0> indices_is; //indices units in sample
+array[M_oos] int<lower=0> indices_oos; //indices units out of sample
+array[D] int<lower=0> indices_spat; //indices ordering the spatial structure
+array[M_is+M_oos,2] int<lower=0> indices_temp; //indexing time matrix with original obs vector
 
 // Spatial structure
 int<lower=0> N_edges; // number edges
 int<lower=0> N_comp; // number disconnected components
-int<lower=0> dim_c[N_comp]; // components sizes
+array[N_comp] int<lower=0> dim_c; // components sizes
 vector<lower=0>[D] scales_ICAR; // scaling factor graph
-int<lower=1, upper=D> node1[N_edges];  // node1[i] adjacent to node2[i]
-int<lower=1, upper=D> node2[N_edges];  // and node1[i] < node2[i]
+array[N_edges] int<lower=1, upper=D> node1;  // node1[i] adjacent to node2[i]
+array[N_edges] int<lower=1, upper=D> node2;  // and node1[i] < node2[i]
 
 // Temporal structure
-int<lower=1, upper=TP> node1_t[TP-1]; //temporal connections
-int<lower=1, upper=TP> node2_t[TP-1]; //temporal connections
+array[TP-1] int<lower=1, upper=TP> node1_t; //temporal connections
+array[TP-1] int<lower=1, upper=TP> node2_t; //temporal connections
 real<lower=0> scale_factor_RW1; // scaling factor temporal graph
-int<lower=0> cat_ios[M_oos]; //Missingness kind for the temporal case
+array[M_oos] int<lower=0> cat_ios; //Missingness kind for the temporal case
 
 ///// data for HS prior
 real<lower=0> sigma_HS; // estimate sigma HS prior

--- a/inst/stan/include/gen_ZIB.stan
+++ b/inst/stan/include/gen_ZIB.stan
@@ -1,5 +1,5 @@
 for(i in 1:M_oos) { // OOS units
-#include /inst/stan/include/gen_reff_OOS.stan
+#include /include/gen_reff_OOS.stan
    if(inflation == 0) {
     if(intercept == 0) {
       theta_oos[i] = (1 - inv_logit(X_oos[i, ] * gamma_p0)) *

--- a/inst/stan/include/gen_ZIB_alt.stan
+++ b/inst/stan/include/gen_ZIB_alt.stan
@@ -1,5 +1,5 @@
 for(i in 1:M_oos) {
-#include /inst/stan/include/gen_reff_OOS.stan
+#include /include/gen_reff_OOS.stan
   if(intercept == 0) {
     theta_oos[i] = inv_logit(X_oos[i, ] * beta + reffs_oos[i] + v_oos[1]);
   }else{

--- a/inst/stan/include/transf_par_ZIB.stan
+++ b/inst/stan/include/transf_par_ZIB.stan
@@ -60,5 +60,5 @@ for(i in 1:M_is) { //IS units
   }else if(inflation == 2) {
     theta[i] = (1 - p0[i] - p1[i]) * mu[i] + p1[i];
   }
-#include /inst/stan/include/transf_par_ab.stan
+#include /include/transf_par_ab.stan
 }

--- a/inst/stan/include/transf_par_ZIBalt.stan
+++ b/inst/stan/include/transf_par_ZIBalt.stan
@@ -15,5 +15,5 @@ for(i in 1:M_is) {
     mu[i] = inv_logit(beta0[1] + X[i, ] * beta + reffs[i]);
   }
   theta[i] = mu[i] * (1 - pow(1 - mu[i], m_d[i]));
-#include /inst/stan/include/transf_par_ab.stan
+#include /include/transf_par_ab.stan
 }

--- a/inst/stan/include/transf_par_beta.stan
+++ b/inst/stan/include/transf_par_beta.stan
@@ -16,5 +16,5 @@ for(i in 1:M_is) { // IS units
   }
   theta[i] = mu[i];
   // definition of parameters a and b
-#include /inst/stan/include/transf_par_ab.stan
+#include /include/transf_par_ab.stan
 }


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
